### PR TITLE
pawn promotion

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -7,6 +7,7 @@
     <title>Vite + React</title>
   </head>
   <body>
+    <div id="modal"></div>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -68,9 +68,39 @@
   background-size: 100%;
 }
 
+.piece-promo { 
+  background-repeat: no-repeat;
+  height:70px;
+  width:70px;
+  background-position: center;
+  background-size: 100%;
+  border-radius: 10px;
+}
+.piece-promo:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+}
+
 .piece:hover { 
   cursor: grab;
 }
 .piece:active{
   cursor: grabbing;
+}
+
+.modal-container {
+width: 100vw;
+height: 100vh;
+position: absolute;
+background-color: rgba(0, 0, 0, 0.2);
+z-index: 1000;
+}
+
+.modal {
+  width: 70px;
+  height: 280px;
+  background-color: white;
+  margin-left:750px;
+  margin-top:200px;
+  border-radius: 10px;
 }

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -1,12 +1,11 @@
 import Tile from "./Tile";
 import { useChessStore } from "../store";
 import { useEffect, useRef } from "react";
-import { movePiece } from "./pieceDragAndDrop";
+import { movePiece } from "../game/pieceDragAndDrop";
 
 const Board = () => {
   const board = useChessStore((state) => state.board);
   const setBoard = useChessStore(state => state.setBoard)
-  // const isPlaying = useChessStore((state) => state.isPlaying);
   const activePiece = useChessStore((state) => state.activePiece);
   const setBoardCoords = useChessStore(state => state.setBoardCoords)
 
@@ -14,6 +13,7 @@ const Board = () => {
   const maxX = useChessStore((state) => state.maxX);
   const minY = useChessStore((state) => state.minY);
   const maxY = useChessStore((state) => state.maxY);
+
 
 
 
@@ -39,7 +39,7 @@ const Board = () => {
       maxY: chessboardRect.bottom
     }
     setBoardCoords(boardCoords)
-  }, [])
+  }, [setBoard, setBoardCoords])
 
 
 

--- a/client/src/components/GameDashBoard.jsx
+++ b/client/src/components/GameDashBoard.jsx
@@ -1,6 +1,7 @@
 
 import { useChessStore } from '../store'
 import CapturedPieces from './CapturedPieces'
+import PawnPromoModal from './PawnPromoModal'
 
 const GameDashBoard = () => {
     const newGame = useChessStore(state => state.newGame)
@@ -9,6 +10,8 @@ const GameDashBoard = () => {
     const turn = useChessStore(state => state.turn)
     const capturedBPieces = useChessStore(state => state.capturedBPieces)
     const capturedWPieces = useChessStore(state => state.capturedWPieces)
+
+    const pawnPromoModal = useChessStore(state => state.pawnPromoModal)
 
     const startGame = () => {
         const game = {
@@ -25,7 +28,7 @@ const GameDashBoard = () => {
             <CapturedPieces pieces={capturedBPieces} color="B" />
             <p>Black:</p>
             <CapturedPieces pieces={capturedWPieces} color="W" />
-
+            <PawnPromoModal pawnPromoModal={pawnPromoModal} />
 
 
         </div>

--- a/client/src/components/PawnPromoModal.jsx
+++ b/client/src/components/PawnPromoModal.jsx
@@ -1,0 +1,47 @@
+import PropTypes from "prop-types";
+import ReactDOM from "react-dom";
+import { useChessStore } from "../store";
+import { getPieceSVG } from "./svg";
+
+
+const PawnPromoModal = ({ pawnPromoModal }) => {
+    const closePawnPromoModal = useChessStore(state => state.closePawnPromoModal)
+    const currTurn = useChessStore(state => state.currTurn)
+    const promoMove = useChessStore(state => state.promoMove)
+    const setPromoMove = useChessStore(state => state.setPromoMove)
+    const commitMove = useChessStore(state => state.commitMove)
+    const incrementTurn = useChessStore(state => state.incrementTurn)
+
+    const pieces = ["KNIGHT", "BISHOP", "ROOK", "QUEEN"]
+
+    const closeModal = async () => {
+        await setPromoMove(null)
+        closePawnPromoModal()
+    }
+
+    const promotePawn = async (piece) => {
+        await commitMove({ ...promoMove, piece: piece })
+        await incrementTurn({ ...promoMove, piece: piece })
+        closeModal()
+    }
+    return ReactDOM.createPortal(
+        <>
+            {pawnPromoModal ? (
+                <div onClick={closeModal} className="modal-container">
+                    <div onClick={e => e.stopPropagation()} className="modal">
+                        {pieces.map((p, idx) => {
+                            const svgURL = getPieceSVG(currTurn + "_" + p)
+                            return (<div key={idx} style={{ backgroundImage: `url(${svgURL})` }} className="piece-promo" id={p} onClick={(e) => promotePawn(e.target.id)} />)
+                        })}
+                    </div>
+                </div>
+            ) : null}
+        </>,
+        document.getElementById("modal")
+    );
+}
+PawnPromoModal.propTypes = {
+    pawnPromoModal: PropTypes.bool.isRequired,
+
+};
+export default PawnPromoModal

--- a/client/src/game/moves.js
+++ b/client/src/game/moves.js
@@ -80,11 +80,7 @@ const validPawnMoves = async (x, y, pieceColor, oppColor, board, isChecked) => {
 
   xMoves.forEach(async (xIncrement) => {
     let newX = x + xIncrement;
-    console.log(newX);
-
     const canAttack = await isTileOccupiedByOpp(newX, newY, oppColor, board);
-    console.log(canAttack);
-
     if (canAttack) validMoves.push({ x: newX, y: newY });
   });
 

--- a/client/src/game/pieceDragAndDrop.js
+++ b/client/src/game/pieceDragAndDrop.js
@@ -4,7 +4,7 @@ export const grabPiece = (e) => {
     const x = e.clientX - 50;
     const y = e.clientY - 50;
     activePiece.style.position = "absolute";
-    activePiece.style.zIndex = "1000";
+    activePiece.style.zIndex = "100";
     activePiece.style.left = `${x}px`;
     activePiece.style.top = `${y}px`;
     activePiece.style.height = "80px";

--- a/client/src/game/scoring.js
+++ b/client/src/game/scoring.js
@@ -1,0 +1,11 @@
+export const getScoreInc = (capturedColor, capturedPiece) => {
+  if (capturedPiece === null) return 0;
+  let score = 0;
+  if (capturedPiece === "PAWN") score = 1;
+  if (capturedPiece === "ROOK") score = 5;
+  if (capturedPiece === "KNIGHT") score = 3;
+  if (capturedPiece === "BISHOP") score = 3;
+  if (capturedPiece === "QUEEN") score = 9;
+  if (capturedColor === "B") score *= -1;
+  return score;
+};

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { BLACK, FILES, RANKS, WHITE } from "./types";
 import newBoard from "./newBoard.json";
+import { getScoreInc } from "./game/scoring";
 
 export const useChessStore = create((set) => ({
   board: [],
@@ -55,7 +56,6 @@ export const useChessStore = create((set) => ({
       board: initBoard,
       isPlaying: false,
       playerColor: playerColor,
-      canCastle: false,
     }));
   },
 
@@ -66,33 +66,53 @@ export const useChessStore = create((set) => ({
   maxY: 0,
   activePiece: null,
   activeTile: null,
-  setActiveTile: (activeTile) => {
+  setActiveTile: (activeTile) =>
     set(() => ({
       activeTile: activeTile,
-    }));
-  },
-  setActivePiece: (activePiece) => {
+    })),
+
+  setActivePiece: (activePiece) =>
     set(() => ({
       activePiece: activePiece,
-    }));
-  },
-  setBoardCoords: (boardCoords) => {
+    })),
+
+  setBoardCoords: (boardCoords) =>
     set(() => ({
       minX: boardCoords.minX,
       maxX: boardCoords.maxX,
       minY: boardCoords.minY,
       maxY: boardCoords.maxY,
-    }));
-  },
-
-  validMoves: [],
-  setValidMoves: (validMoves) => {
-    set(() => ({
-      validMoves: validMoves,
-    }));
-  },
+    })),
 
   // game functions
+  // store list of valid moves for active piece
+  validMoves: [],
+  setValidMoves: (validMoves) =>
+    set(() => ({
+      validMoves: validMoves,
+    })),
+
+  // PROMOTE PAWN
+  promotePawn: ({ x, y, piece }) => {
+    set((state) => ({
+      board: state.board.map((t) => {
+        if (t.x === x && t.y === y) {
+          return {
+            ...t,
+            piece: piece,
+          };
+        }
+      }),
+    }));
+  },
+
+  pawnPromoModal: false,
+  openPawnPromoModal: () => set(() => ({ pawnPromoModal: true })),
+  closePawnPromoModal: () => set(() => ({ pawnPromoModal: false })),
+
+  promoMove: null,
+  setPromoMove: (move) => set(() => ({ promoMove: move })),
+
   // INCREMENT TURN
   incrementTurn: (move) => {
     const capturedColor = move.capturedPiece.pieceColor === "W" ? "W" : "B";
@@ -197,6 +217,11 @@ export const useChessStore = create((set) => ({
       opponentId: opponentId,
       canLongCastle: true,
       canShortCastle: true,
+      moveHistory: [],
+      turn: 0,
+      currTurn: "W",
+      score: 0,
+      activePiece: null,
       capturedWPieces: [
         { piece: "PAWN", count: [] },
         { piece: "ROOK", count: [] },
@@ -214,15 +239,3 @@ export const useChessStore = create((set) => ({
     }));
   },
 }));
-
-const getScoreInc = (capturedColor, capturedPiece) => {
-  if (capturedPiece === null) return 0;
-  let score = 0;
-  if (capturedPiece === "PAWN") score = 1;
-  if (capturedPiece === "ROOK") score = 5;
-  if (capturedPiece === "KNIGHT") score = 3;
-  if (capturedPiece === "BISHOP") score = 3;
-  if (capturedPiece === "QUEEN") score = 9;
-  if (capturedColor === "B") score *= -1;
-  return score;
-};


### PR DESCRIPTION
When a pawn reaches 1st or 8th rank, it can be promoted to a knight, bishop, rook, or queen. 

- modal opens on game dashboard
- when user clicks outside modal, modal closes and move is not committed
- when user selects a piece to promote to, the pawn is replaced by the new piece and the move is committed